### PR TITLE
Android で一部 option が内部実装に反映されていなかった問題を修正

### DIFF
--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetBuilder.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityWidgetBuilder.kt
@@ -19,6 +19,12 @@ class FlutterUnityWidgetBuilder : FlutterUnityWidgetOptionsSink {
                 binaryMessenger,
                 lifecycle
         )
+
+        controller.setFullscreenEnabled(options.fullscreenEnabled)
+        controller.setHideStatusBar(options.hideStatus)
+        controller.setRunImmediately(options.runImmediately)
+        controller.setUnloadOnDispose(options.unloadOnDispose)
+
         controller.bootstrap()
 
         return controller


### PR DESCRIPTION
（Android 向けの修正）
`FlutterUnityWidgetFactory` に渡された一部パラメータ（fullscreen, hideStatus, earlyInitUnity, unloadOnDispose）が `FlutterUnityWidgetController` に渡されず、Widget の dispose 時にアンロードが走らない状態になっていたのを修正する