### PR TITLE
Android 12でBackButtonに関する例外が出る問題のworkaroundを適用する

### DIFF
--- a/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityActivity.kt
+++ b/android/src/main/kotlin/com/xraph/plugin/flutter_unity_widget/FlutterUnityActivity.kt
@@ -1,6 +1,6 @@
 package com.xraph.plugin.flutter_unity_widget
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
 /* 
 The following Unity versions expect the mUnityPlayer property on the main activity: 
@@ -14,7 +14,7 @@ Implement FlutterUnityActivity or the interface to fix these plugins.
 https://github.com/juicycleff/flutter-unity-view-widget/pull/908
 */
 
-open class FlutterUnityActivity: FlutterActivity() {
+open class FlutterUnityActivity: FlutterFragmentActivity() {
     @JvmField
     var mUnityPlayer: java.lang.Object? = null;
 }


### PR DESCRIPTION
Android 12におけるuser-visibleではないもののエラーが出ている問題への対策です。

https://github.com/juicycleff/flutter-unity-view-widget/issues/957#issuecomment-2548214463

上記のissueコメントに則ってActivityの継承元を変更したい…というPRです。